### PR TITLE
MORE TGU fixes

### DIFF
--- a/_maps/heliostation.json
+++ b/_maps/heliostation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar", "/area/security/prison/upper"]
+			"additional_cqc_areas": ["/area/station/service/bar", "/area/station/security/prison/upper"]
 		},
 		"prisoner": {
 			"spawn_positions": 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -125,7 +125,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast-Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/explab)
@@ -144,7 +144,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast-Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
@@ -308,7 +308,7 @@
 "aaZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -2787,7 +2787,7 @@
 "ajL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
-	name = "prison blast door"
+	name = "Prison Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -3321,7 +3321,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hos_spess_shutters";
-	name = "Space shutters"
+	name = "Space Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4360,7 +4360,6 @@
 	name = "Brig Control"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -5057,7 +5056,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -6396,7 +6395,7 @@
 "auK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -7150,7 +7149,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/item/radio,
 /turf/open/floor/iron/dark,
@@ -7165,7 +7164,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/structure/table/reinforced,
 /obj/item/folder/red{
@@ -7179,7 +7178,7 @@
 /obj/item/pen,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/machinery/door/window/left/directional/south{
 	base_state = "right";
@@ -7385,7 +7384,7 @@
 "axE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
-	name = "prisoner processing blast door"
+	name = "Prisoner Processing Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -9793,7 +9792,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -10191,7 +10190,7 @@
 "aHd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -10215,7 +10214,7 @@
 "aHe" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -10231,7 +10230,7 @@
 "aHg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -14073,7 +14072,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/item/folder/red,
 /obj/item/pen,
@@ -14270,7 +14269,6 @@
 "aYl" = (
 /obj/structure/table/wood,
 /obj/item/soap,
-/obj/structure/table/wood,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
 /turf/open/floor/iron/dark,
@@ -15183,7 +15181,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/item/crowbar,
 /obj/effect/turf_decal/delivery,
@@ -18577,7 +18575,7 @@
 "bpN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -18957,7 +18955,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -18965,7 +18963,7 @@
 "bqI" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18974,7 +18972,7 @@
 "bqJ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -18990,7 +18988,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -18998,7 +18996,7 @@
 "bqL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -20360,7 +20358,7 @@
 "bvG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/structure/sign/warning/secure_area{
 	pixel_x = 32
@@ -20798,7 +20796,7 @@
 "bxp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
@@ -21291,7 +21289,7 @@
 "byO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/secure_area{
@@ -21433,7 +21431,7 @@
 "bzk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21443,7 +21441,7 @@
 "bzl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -21458,7 +21456,7 @@
 "bzm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21467,7 +21465,7 @@
 "bzn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21477,7 +21475,7 @@
 "bzp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21486,7 +21484,7 @@
 "bzq" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21496,7 +21494,7 @@
 "bzr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -21511,7 +21509,7 @@
 "bzs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -24268,7 +24266,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
@@ -24277,7 +24275,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
@@ -26820,7 +26818,7 @@
 "bUo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/directional/north{
@@ -27115,7 +27113,7 @@
 "bVc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27618,7 +27616,7 @@
 "bWF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -27632,7 +27630,7 @@
 "bWG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -27946,7 +27944,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ce_privacy";
-	name = "Privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -32566,7 +32564,7 @@
 "czw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
-	name = "prison blast door"
+	name = "Prison Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -34441,7 +34439,7 @@
 "eca" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37946,7 +37944,7 @@
 "hiN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -38074,7 +38072,7 @@
 "hmL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -38199,7 +38197,7 @@
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39574,7 +39572,7 @@
 "iNH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/north,
@@ -40237,7 +40235,7 @@
 "jBx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41305,7 +41303,7 @@
 "kAo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/newscaster/directional/east,
@@ -42017,7 +42015,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/landmark/start/hangover,
@@ -42271,7 +42269,7 @@
 "ltk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -42648,7 +42646,7 @@
 "lRu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "surgerya";
-	name = "privacy shutter"
+	name = "Privacy Shutter"
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43243,7 +43241,7 @@
 "msw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -43371,7 +43369,7 @@
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/directions/evac{
@@ -43459,7 +43457,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44544,7 +44542,7 @@
 "nEb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46043,7 +46041,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -46487,7 +46485,7 @@
 "pkU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -47297,7 +47295,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -47667,7 +47665,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/explab)
@@ -47943,7 +47941,7 @@
 "qtF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48492,7 +48490,7 @@
 "qVP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -50792,7 +50790,7 @@
 "sQx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -51528,7 +51526,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -51673,7 +51671,7 @@
 "twQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -52636,7 +52634,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/breakroom)
@@ -52889,7 +52887,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -53539,7 +53537,7 @@
 "uUY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -53675,7 +53673,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -55498,7 +55496,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
-	name = "prisoner processing blast door"
+	name = "Prisoner Processing Blast Door"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -55609,7 +55607,7 @@
 "wDf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55915,7 +55913,7 @@
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -56721,7 +56719,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -56859,7 +56857,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -56950,7 +56948,7 @@
 "xxO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";

--- a/_maps/pubbystation.json
+++ b/_maps/pubbystation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar/atrium", "/area/security/prison/upper"]
+			"additional_cqc_areas": ["/area/station/service/bar/atrium", "/area/station/security/prison/upper"]
 		},
 		"prisoner": {
 			"spawn_positions": 2

--- a/_maps/selenestation.json
+++ b/_maps/selenestation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar/atrium", "/area/service/hydroponics", "/area/security/prison/upper"]
+			"additional_cqc_areas": ["/area/station/service/bar/atrium", "/area/station/service/hydroponics", "/area/station/security/prison/upper"]
 		},
 		"prisoner": {
 			"spawn_positions": 4

--- a/fulp_modules/mapping/shuttles/evac/emergency_selene.dmm
+++ b/fulp_modules/mapping/shuttles/evac/emergency_selene.dmm
@@ -173,9 +173,9 @@
 /area/shuttle/escape)
 "oj" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ou" = (
@@ -381,9 +381,9 @@
 /area/shuttle/escape)
 "wR" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "xs" = (
@@ -604,9 +604,10 @@
 /area/shuttle/escape)
 "OP" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_one_access_txt = "2;19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Pa" = (


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
